### PR TITLE
Fix preview URL over tunnels

### DIFF
--- a/files/var/www/cgi-bin/p/common.cgi
+++ b/files/var/www/cgi-bin/p/common.cgi
@@ -526,7 +526,7 @@ async function updatePreview() {
   }
 }
 
-const pimg='http://${network_address}/image.jpg';
+const pimg = document.location.protocol + "//" + document.location.hostname + (document.location.port ? ':' + document.location.port : '')  + '/image.jpg';
 const jpg = new Image();
 jpg.addEventListener('load', async function() {
   await sleep(${refresh_rate} * 1000);


### PR DESCRIPTION
Image on preview page is now using current protocol, hostname and port from page location to make correct URL when connected over tunnels.