### PR TITLE
Replacing cp with cat in some instances to overcome overlayFS bug

### DIFF
--- a/files/usr/sbin/updatewebui.sh
+++ b/files/usr/sbin/updatewebui.sh
@@ -66,7 +66,9 @@ for upd_file in $(find $upd_dir -type f -or -type l); do
   # echo "Overlay file ${ovl_file}"
   if [ ! -f "$ovl_file" ] || [ "$(diff -q $ovl_file $upd_file)" ]; then
     [ ! -d "${ovl_file%/*}" ] && mkdir -p $(dirname $ovl_file)
-    cp $v_opts -f $upd_file $ovl_file
+    # overlayFS workaround
+    # cp $v_opts -f $upd_file $ovl_file
+    cat $upd_file  > $ovl_file
   fi
 done
 

--- a/files/var/www/cgi-bin/majestic-settings.cgi
+++ b/files/var/www/cgi-bin/majestic-settings.cgi
@@ -67,7 +67,9 @@ if [ "POST" = "$REQUEST_METHOD" ]; then
   IFS=$OIFS
 
   # update config if differs
-  [ -n "$(diff -q $temp_yaml $mj_conf)" ] && cp -f $temp_yaml $mj_conf
+  # overlayFS workaround
+  #[ -n "$(diff -q $temp_yaml $mj_conf)" ] && cp -f $temp_yaml $mj_conf
+  [ -n "$(diff -q $temp_yaml $mj_conf)" ] && cat $temp_yaml > $mj_conf
 
   # clean up
   rm $temp_yaml

--- a/files/var/www/cgi-bin/network-ntp.cgi
+++ b/files/var/www/cgi-bin/network-ntp.cgi
@@ -10,7 +10,9 @@ config_file="/etc/${plugin}.conf"
 if [ "POST" = "$REQUEST_METHOD" ]; then
   case "$POST_action" in
     reset)
-      cp /rom/etc/ntp.conf /etc/ntp.conf
+      # OverlayFS workaround
+      #cp /rom/etc/ntp.conf /etc/ntp.conf
+      cat /rom/etc/ntp.conf > /etc/ntp.conf
       redirect_back "success" "Configuration reset to firmware defaults."
       ;;
     sync)

--- a/files/var/www/cgi-bin/plugin-motion.cgi
+++ b/files/var/www/cgi-bin/plugin-motion.cgi
@@ -46,7 +46,9 @@ if [ "POST" = "$REQUEST_METHOD" ]; then
       if [ -z "$(eval echo "DEBUG TRACE" | sed -n "/\b$(yaml-cli -g .system.logLevel)\b/p")" ]; then
         # make required changes to majestic.yaml
         _t=$(mktemp)
-        cp -f /tmp/majestic.yaml $_t
+        #overlayFS workaround
+        #cp -f /tmp/majestic.yaml $_t
+        cat /tmp/majestic.yaml > $_t
         yaml-cli -i $_t -s .system.logLevel DEBUG
         yaml-cli -i $_t -s .motionDetect.visualize true
         yaml-cli -i $_t -s .motionDetect.debug true


### PR DESCRIPTION
"overlayfs: ERROR - failed to whiteout 'majestic.yaml'"

I think this bug affects overlayFS up to version v20 but this is not tested.

Background: when a file is overwritten with cp on the lower FS the kernel first tryies to white it out (mark as deleted) which fails. With cat it seems working as it is threated as edit. When a file is edited it first copied to the upper file system then modified.

https://github.com/OpenIPC/firmware/issues/248
and
https://github.com/OpenIPC/firmware/issues/318