### PR TITLE
turn white led, without switching to black and white

### DIFF
--- a/files/var/www/cgi-bin/night.cgi
+++ b/files/var/www/cgi-bin/night.cgi
@@ -3,9 +3,13 @@
 <%
 case "$POST_mode" in
   on)
+    test "no" == "$POST_bw" && \
+    echo 1 > /sys/class/gpio/gpio$(cli -g .nightMode.backlightPin)/value || \
     curl -s http://127.0.0.1/night/on
     ;;
   off)
+    test "no" == "$POST_bw" && \
+    echo 0 > /sys/class/gpio/gpio$(cli -g .nightMode.backlightPin)/value || \
     curl -s http://127.0.0.1/night/off
     ;;
   toggle)


### PR DESCRIPTION
Majestic night api ```/night/{on,off}``` always
switching to black and white.

Same api could also be accessed indirectly via ```/cgi-bin/night.cgi``` script.

I added another post param ```bw``` to it, which if equals ```no``` turns backlight with GPIO. And if not, everything works as before.

Usage
```
curl -s -v -u root:12341234 -d 'mode=on' -d 'bw=no' http://127.0.0.1:85/cgi-bin/night.cgi
```
